### PR TITLE
fixed overlapping masonry items issue

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -17,5 +17,6 @@ var app = new EmberAddon();
 // modules that you would like to import into your application
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
+app.import('bower_components/imagesloaded/imagesloaded.pkgd.min.js');
 
 module.exports = app.toTree();

--- a/app/components/masonry-grid.js
+++ b/app/components/masonry-grid.js
@@ -22,6 +22,7 @@ export default Ember.Component.extend({
   items: null,
 
   initializeMasonry: function () {
+    var _this = this;
     var options = getOptions.call(this, [
           'containerStyle',
           'columnWidth',
@@ -38,6 +39,8 @@ export default Ember.Component.extend({
           'visibleStyle'
         ]);
 
-    this.$().masonry(options);
+    imagesLoaded(Ember.$('.masonry-grid'), function(){
+      _this.$().masonry(options);
+    });
   }.on('didInsertElement').observes('items.length')
 });

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0",
-    "jquery-masonry": "~3.2.2"
+    "jquery-masonry": "~3.2.2",
+    "imagesloaded": "~3.1.8"
   }
 }

--- a/index.js
+++ b/index.js
@@ -8,5 +8,6 @@ module.exports = {
     this._super.included(app);
 
     app.import(app.bowerDirectory + '/jquery-masonry/dist/masonry.pkgd.min.js');
+    app.import(app.bowerDirectory + '/imagesloaded/imagesloaded.pkgd.min.js');
   }
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,19 @@
 <h2 id='title'>Welcome to Ember.js</h2>
 
 {{#masonry-grid}}
-  <div class="item">foo</div>
+
+  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
+  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
+  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
+  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
+  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
+
+  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
+
+  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
+  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
+  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
+  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
+  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
+
 {{/masonry-grid}}


### PR DESCRIPTION
- unloaded images throw off masonry layouts and cause item elements to overlap
- used imagesLoaded to to solve this issue and updated bower dependencies
- updated dummy app to illustrate the problem (remove imagesLoaded dependency to replicate the problem)
