### PR TITLE
Masonry reloading after changes to items property

### DIFF
--- a/addon/components/masonry-grid.js
+++ b/addon/components/masonry-grid.js
@@ -23,6 +23,8 @@ export default Ember.Component.extend({
   options: null,
   items: null,
 
+  masonryInitialized: false,
+
   initializeMasonry: Ember.on('didInsertElement', function () {
     this.set('options', getOptions.call(this, [
       'containerStyle',
@@ -43,11 +45,16 @@ export default Ember.Component.extend({
     this.layoutMasonry();
   }),
 
-  layoutMasonry: Ember.observer('items.length', function () {
+  layoutMasonry: Ember.observer('items.@each', function () {
     var _this = this;
 
     imagesLoaded(this.$(), function () {
+      if (_this.get('masonryInitialized')) {
+        _this.$().masonry('destroy');
+      }
+
       _this.$().masonry(_this.get('options'));
+      _this.set('masonryInitialized', true);
     });
   })
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+
+export default Ember.ArrayController.extend({
+  first: true,
+  currentObject: null,
+
+  init: function () {
+    this._super.apply(this, arguments);
+
+    var model = [
+      { 'items': Ember.A([]) },
+      { 'items': Ember.A([]) }
+    ];
+
+    model.forEach(function (obj) {
+      for (let i = 0; i < 20; i++) {
+        obj['items'].push({
+          imgsrc: 'https://placekitten.com/g/200/300',
+          name: 'Mittens'
+        });
+      }
+    });
+
+    model = Ember.A(model);
+
+    this.set('model', model);
+    this.set('currentObject', this.get('model').objectAt(0));
+  },
+
+  actions: {
+    switchObject: function () {
+      this.set('first', !this.get('first'));
+
+      this.set('currentObject', this.get('model').objectAt(this.get('first') ? 0 : 1));
+    }
+  }
+});

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>Ember Masonry Grid</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,19 +1,3 @@
-<h2 id='title'>Welcome to Ember.js</h2>
+<h2 id='title'>Ember Masonry Grid</h2>
 
-{{#masonry-grid}}
-
-  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
-  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
-  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
-  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
-  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
-
-  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
-
-  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
-  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
-  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
-  <div class="item" style="width: 200px; background-color: red;"><img src="https://placekitten.com/g/200/300"></div>
-  <div class="item" style="width: 200px; background-color: blue;"><img src="https://placekitten.com/g/200/300"></div>
-
-{{/masonry-grid}}
+{{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,11 @@
+<a href="#" {{action 'switchObjects'}}>Switch Models</a>
+
+{{#masonry-grid items=currentObject.items}}
+  {{#each currentObject.items}}
+    <div class="item">
+      <img src="{{imgsrc}}"><br>
+      {{name}}<br>
+      {{input type="text" value=name}}
+    </div>
+  {{/each}}
+{{/masonry-grid}}


### PR DESCRIPTION
Whenever the `items` property changes, we're now destroying the current Masonry instance and reinitializing with the new DOM elements.
