### PR TITLE
Make grid invisible while recalculating

### DIFF
--- a/addon/components/masonry-grid.js
+++ b/addon/components/masonry-grid.js
@@ -47,6 +47,7 @@ export default Ember.Component.extend({
 
   layoutMasonry: Ember.observer('items.@each', function () {
     var _this = this;
+    this.set('isVisible', false);
 
     imagesLoaded(this.$(), function () {
       if (_this.get('masonryInitialized')) {
@@ -55,6 +56,7 @@ export default Ember.Component.extend({
 
       _this.$().masonry(_this.get('options'));
       _this.set('masonryInitialized', true);
+      _this.set('isVisible', true);
     });
   })
 });


### PR DESCRIPTION
This helps preventing the flickering that happens when the grid is being calculated (and the images are potentially not loaded).
