### PR TITLE
remove deprecated use of @each to watch arrays

### DIFF
--- a/addon/components/masonry-grid.js
+++ b/addon/components/masonry-grid.js
@@ -45,7 +45,7 @@ export default Ember.Component.extend({
     this.layoutMasonry();
   }),
 
-  layoutMasonry: Ember.observer('items.@each', function () {
+  layoutMasonry: Ember.observer('items.[]', function () {
     var _this = this;
 
     imagesLoaded(this.$(), function () {


### PR DESCRIPTION
@each throws an error in Ember 2+

This hasn't been tested this in earlier versions, so not sure where backwards compatibility issues may occur.

```
Uncaught Error: Assertion Failed: Depending on arrays using a dependent key ending with `@each` is no longer supported. Please refactor from `Ember.observer('items.@each', function() {});` to `Ember.observer('items.[]', function() {})`.
```
