### PR TITLE
Adds FastBoot compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,16 @@ module.exports = {
   included: function (app) {
     this._super.included(app);
 
-    app.import({
-      development: app.bowerDirectory + '/masonry/dist/masonry.pkgd.js',
-      production: app.bowerDirectory + '/masonry/dist/masonry.pkgd.min.js'
-    });
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import({
+        development: app.bowerDirectory + '/masonry/dist/masonry.pkgd.js',
+        production: app.bowerDirectory + '/masonry/dist/masonry.pkgd.min.js'
+      });
 
-    app.import({
-      development: app.bowerDirectory + '/imagesloaded/imagesloaded.pkgd.js',
-      production: app.bowerDirectory + '/imagesloaded/imagesloaded.pkgd.min.js'
-    });
+      app.import({
+        development: app.bowerDirectory + '/imagesloaded/imagesloaded.pkgd.js',
+        production: app.bowerDirectory + '/imagesloaded/imagesloaded.pkgd.min.js'
+      });
+    }
   }
 };


### PR DESCRIPTION
The libraries that this addon pulls in cause apps running in FastBoot to crash on boot. This change only imports Bower dependencies in the browser build, allowing it to boot normally.
